### PR TITLE
feat: Add https server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ $ npm install @podium/test-utils --save-dev
 This module contain the following utils:
 
  * [PodletServer](/lib/podlet-server) - A dummy Podlet server with misc hooks to tap into manipulate the server on the fly.
+ * [HttpsServer](/lib/https-server) - A simple https server with a request hook to insert a simple response.
  * [HttpServer](/lib/http-server) - A simple http server with a request hook to insert a simple response.
  * [request](/lib/http-request) - A simple http request client.
  * [destinationObjectStream](/lib/stream-utils) - A stream util to pipe Objects into. Calls a callback with all Objects streamed into it when done.

--- a/lib/http-request/request.js
+++ b/lib/http-request/request.js
@@ -12,8 +12,8 @@ const request = (
         json = false,
     } = {},
     payload,
-) => {
-    return new Promise((resolve, reject) => {
+) =>
+    new Promise((resolve, reject) => {
         const url = new URL(pathname, address);
 
         if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
@@ -35,9 +35,9 @@ const request = (
         };
 
         const req = http
-            .request(options, res => {
+            .request(options, (res) => {
                 const chunks = [];
-                res.on('data', chunk => {
+                res.on('data', (chunk) => {
                     chunks.push(chunk);
                 });
                 res.on('end', () => {
@@ -50,7 +50,7 @@ const request = (
                     });
                 });
             })
-            .on('error', error => {
+            .on('error', (error) => {
                 reject(error);
             });
 
@@ -60,5 +60,4 @@ const request = (
 
         req.end();
     });
-};
 module.exports = request;

--- a/lib/http-server/server.js
+++ b/lib/http-server/server.js
@@ -20,7 +20,7 @@ class HttpServer {
     }
 
     listen() {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             this.server = this.app.listen(0, 'localhost', () => {
                 this.address = `http://${this.server.address().address}:${
                     this.server.address().port
@@ -32,7 +32,7 @@ class HttpServer {
 
     close() {
         return new Promise((resolve, reject) => {
-            this.server.close(err => {
+            this.server.close((err) => {
                 if (err) {
                     reject(err);
                 } else {
@@ -51,9 +51,9 @@ class HttpServer {
                 opts = url.parse(this.address);
             }
 
-            http.get(opts, res => {
+            http.get(opts, (res) => {
                 const chunks = [];
-                res.on('data', chunk => {
+                res.on('data', (chunk) => {
                     chunks.push(chunk);
                 });
                 res.on('end', () => {
@@ -64,7 +64,7 @@ class HttpServer {
                             : JSON.parse(chunks.join('')),
                     });
                 });
-            }).on('error', error => {
+            }).on('error', (error) => {
                 reject(error);
             });
         });

--- a/lib/https-server/README.md
+++ b/lib/https-server/README.md
@@ -1,0 +1,106 @@
+# HttpsServer
+
+A dummy https server. The server is signed with a temporary, in memory, self signed certificate.
+
+When requesting a server signed with a self signed certificate from node.js do set `rejectUnauthorized` to `false` when doing the request to ignore the self signed certificate warning.
+
+## Installation
+
+```bash
+$ npm install @podium/test-utils --save-dev
+```
+
+## Getting started
+
+Start a https server at any random available http port
+
+```js
+const { HttpsServer } = require('@podium/test-utils');
+
+const server = new HttpsServer();
+server.request = (req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/plain');
+    res.end('hello world');
+};
+
+const service = await server.listen();
+
+console.log(service) // addresses to server.
+
+await server.close();
+```
+
+## Constructor
+
+Create a new https server.
+
+```js
+const server = new HttpsServer();
+```
+
+
+## API methods
+
+The https server instance has the following API:
+
+### .listen()
+
+Starts the https server listening on a random available port. Returns a
+`promise` which will resolve with the address of the running instance.
+
+```js
+const server = new HttpsServer();
+const service = await server.listen();
+console.log(service) // addresses to server etc.
+```
+
+### .close()
+
+Closes the running instance. Returns a `promise` which will resolve when all
+open connections to the instance is closed and the server is properly closed.
+
+### .get(options)
+
+Helpe method to request any path on the server instance. Returns a `promise` 
+which will resolve with the data of the request.
+
+Example: 
+
+```js
+const server = new HttpsServer();
+server.request = (req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/plain');
+    res.end(JSON.stringify({ data: 'hello world' }));
+};
+
+await server.listen();
+
+const data = await server.get({ pathname: '/foo' });
+console.log(data);
+
+await server.close();
+```
+
+#### options
+
+The method takes the following options:
+ 
+  * `pathname` - `String` - A pathname on the server to request. Defaults to `/`.
+
+## API properties
+
+### .request
+
+A `setter` for a function to be run on each request. Function will be called
+with `request` and `response` object.
+
+```js
+const server = new HttpsServer();
+server.request = (req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ status: 'ok' }));
+}
+```

--- a/lib/https-server/server.js
+++ b/lib/https-server/server.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const selfsigned = require('selfsigned');
+const { URL } = require('url');
+const https = require('https');
+
+const attrs = [{ name: 'commonName', value: 'podium-lib.io' }];
+const PEMS = selfsigned.generate(attrs, { days: 365 });
+
+class HttpsServer {
+    constructor() {
+        this.address = '';
+        this.request = undefined;
+        this.server = undefined;
+        this.app = https.createServer(
+            {
+                key: PEMS.private,
+                cert: PEMS.cert,
+            },
+            (req, res) => {
+                if (this.request) {
+                    this.request(req, res);
+                    return;
+                }
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/plain');
+                res.end('ok');
+            },
+        );
+    }
+
+    listen() {
+        return new Promise((resolve) => {
+            this.server = this.app.listen(0, 'localhost', () => {
+                this.address = `https://${this.server.address().address}:${
+                    this.server.address().port
+                }`;
+                resolve(this.address);
+            });
+        });
+    }
+
+    close() {
+        return new Promise((resolve, reject) => {
+            this.server.close((err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    get(
+        options = {
+            pathname: '/',
+        },
+    ) {
+        return new Promise((resolve, reject) => {
+            const url = new URL(options.pathname, this.address);
+
+            const opts = {
+                rejectUnauthorized: false,
+                protocol: url.protocol,
+                pathname: url.pathname,
+                hostname: url.hostname,
+                port: url.port,
+            };
+
+            https
+                .get(opts, (res) => {
+                    const chunks = [];
+                    res.on('data', (chunk) => {
+                        chunks.push(chunk);
+                    });
+                    res.on('end', () => {
+                        resolve({
+                            headers: res.headers,
+                            response: options.raw
+                                ? chunks.join('')
+                                : JSON.parse(chunks.join('')),
+                        });
+                    });
+                })
+                .on('error', (error) => {
+                    reject(error);
+                });
+        });
+    }
+}
+
+module.exports = HttpsServer;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const PodletServer = require('./podlet-server/server');
+const HttpsServer = require('./https-server/server');
 const HttpServer = require('./http-server/server');
 const request = require('./http-request/request');
 const streams = require('./stream-utils/streams');
@@ -8,5 +9,6 @@ const streams = require('./stream-utils/streams');
 module.exports.destinationObjectStream = streams.destinationObjectStream;
 module.exports.destinationBufferStream = streams.destinationBufferStream;
 module.exports.PodletServer = PodletServer;
+module.exports.HttpsServer = HttpsServer;
 module.exports.HttpServer = HttpServer;
 module.exports.request = request;

--- a/lib/podlet-server/server.js
+++ b/lib/podlet-server/server.js
@@ -45,7 +45,7 @@ class PodletServer extends EventEmitter {
         }
 
         // TODO: Make it so that "proxy" is not set through constructor
-        Object.keys(proxy).forEach(key => {
+        Object.keys(proxy).forEach((key) => {
             this._podlet.proxy({ target: proxy[key], name: key });
         });
 
@@ -92,7 +92,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'version', {
             get: () => this._podlet.version,
-            set: value => {
+            set: (value) => {
                 this._manifest.version = value;
             },
             configurable: true,
@@ -124,7 +124,7 @@ class PodletServer extends EventEmitter {
                     css: this._podlet.css(),
                     js: this._podlet.js(),
                 }),
-            set: value => {
+            set: (value) => {
                 // TODO: does probably not work as is (not in use since no tests break)
                 if (!this._manifest.assets) {
                     this._manifest.assets = {};
@@ -137,7 +137,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'headersManifest', {
             get: () => this._headersManifest,
-            set: value => {
+            set: (value) => {
                 this._headersManifest = value;
             },
             configurable: true,
@@ -146,7 +146,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'headersContent', {
             get: () => this._headersContent,
-            set: value => {
+            set: (value) => {
                 this._headersContent = value;
             },
             configurable: true,
@@ -155,7 +155,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'statusCode', {
             get: () => this._statusCode,
-            set: value => {
+            set: (value) => {
                 this._statusCode = value;
             },
             configurable: true,
@@ -164,7 +164,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'headersFallback', {
             get: () => this._headersFallback,
-            set: value => {
+            set: (value) => {
                 this._headersFallback = value;
             },
             configurable: true,
@@ -173,7 +173,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'manifestBody', {
             get: () => this._bodyManifest,
-            set: value => {
+            set: (value) => {
                 this._bodyManifest = value;
             },
             configurable: true,
@@ -182,7 +182,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'contentBody', {
             get: () => this._bodyContent,
-            set: value => {
+            set: (value) => {
                 this._bodyContent = value;
             },
             configurable: true,
@@ -191,7 +191,7 @@ class PodletServer extends EventEmitter {
 
         Object.defineProperty(this, 'fallbackBody', {
             get: () => this._bodyFallback,
-            set: value => {
+            set: (value) => {
                 this._bodyFallback = value;
             },
             configurable: true,
@@ -223,7 +223,7 @@ class PodletServer extends EventEmitter {
                 res.statusCode = this._statusCode || 200;
                 res.setHeader('Content-Type', 'text/html; charset=utf-8');
                 res.setHeader('podlet-version', this._podlet.version);
-                Object.keys(this._headersContent).forEach(key => {
+                Object.keys(this._headersContent).forEach((key) => {
                     res.setHeader(key, this._headersContent[key]);
                 });
                 res.end(this._podlet.render(inc, this._bodyContent));
@@ -239,7 +239,7 @@ class PodletServer extends EventEmitter {
                 res.statusCode = 200;
                 res.setHeader('Content-Type', 'text/html; charset=utf-8');
                 res.setHeader('podlet-version', this._podlet.version);
-                Object.keys(this._headersFallback).forEach(key => {
+                Object.keys(this._headersFallback).forEach((key) => {
                     res.setHeader(key, this._headersFallback[key]);
                 });
                 res.end(this._podlet.render(inc, this._bodyFallback));
@@ -255,7 +255,7 @@ class PodletServer extends EventEmitter {
                 res.statusCode = 200;
                 res.setHeader('Content-Type', 'application/json');
                 res.setHeader('podlet-version', this._podlet.version);
-                Object.keys(this._headersManifest).forEach(key => {
+                Object.keys(this._headersManifest).forEach((key) => {
                     res.setHeader(key, this._headersManifest[key]);
                 });
                 res.end(this._bodyManifest);
@@ -286,7 +286,7 @@ class PodletServer extends EventEmitter {
                 req.method === 'POST'
             ) {
                 const payload = [];
-                req.on('data', chunk => {
+                req.on('data', (chunk) => {
                     payload.push(chunk);
                 }).on('end', () => {
                     res.statusCode = 200;
@@ -309,7 +309,7 @@ class PodletServer extends EventEmitter {
                 req.method === 'PUT'
             ) {
                 const payload = [];
-                req.on('data', chunk => {
+                req.on('data', (chunk) => {
                     payload.push(chunk);
                 }).on('end', () => {
                     res.statusCode = 200;
@@ -335,7 +335,7 @@ class PodletServer extends EventEmitter {
 
     listen(host = 'http://localhost:0') {
         const addr = url.parse(host);
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             this._server = this._app.listen(
                 { host: addr.hostname, port: parseInt(addr.port, 10) },
                 () => {
@@ -365,7 +365,7 @@ class PodletServer extends EventEmitter {
     close() {
         if (this._server) {
             return new Promise((resolve, reject) => {
-                this._server.destroy(err => {
+                this._server.destroy((err) => {
                     if (err) {
                         reject(err);
                     } else {

--- a/lib/stream-utils/streams.js
+++ b/lib/stream-utils/streams.js
@@ -2,7 +2,7 @@
 
 const stream = require('readable-stream');
 
-const destinationObjectStream = done => {
+const destinationObjectStream = (done) => {
     const arr = [];
 
     const dStream = new stream.Writable({
@@ -21,7 +21,7 @@ const destinationObjectStream = done => {
 };
 module.exports.destinationObjectStream = destinationObjectStream;
 
-const destinationBufferStream = done => {
+const destinationBufferStream = (done) => {
     const buffer = [];
 
     const dStream = new stream.Writable({

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   },
   "author": "Trygve Lie",
   "dependencies": {
-    "readable-stream": "3.6.0",
     "@podium/podlet": "4.4.31",
-    "server-destroy": "1.0.1",
-    "@podium/utils": "4.4.23"
+    "@podium/utils": "4.4.23",
+    "readable-stream": "3.6.0",
+    "selfsigned": "1.10.11",
+    "server-destroy": "1.0.1"
   },
   "devDependencies": {
     "eslint": "7.30.0",


### PR DESCRIPTION
This adds a dummy https server, identical to the [http server](https://github.com/podium-lib/test-utils/tree/master/lib/http-server), intended for testing purposes.

The server is signed with a temporary, in memory, self signed certificate for easy usage. This free us from having to deal with manually setting up certificates and keeping certificates checked into the repo or in the CI. The only downside of this is that `rejectUnauthorized` has to be set to `false` as an option in the https client requesting data from this server but that is a small trade off in my mind.

There are some lint fixes in this PR too. The main change is in the `lib/https-server` directory.