### PR TITLE
fix: Add server destroy to http(s) test servers

### DIFF
--- a/lib/http-server/server.js
+++ b/lib/http-server/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const enableDestroy = require('server-destroy');
 const http = require('http');
 const url = require('url');
 
@@ -27,19 +28,23 @@ class HttpServer {
                 }`;
                 resolve(this.address);
             });
+            enableDestroy(this.server);
         });
     }
 
     close() {
-        return new Promise((resolve, reject) => {
-            this.server.close((err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
+        if (this.server) {
+            return new Promise((resolve, reject) => {
+                this.server.destroy((err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
             });
-        });
+        }
+        return Promise.resolve();
     }
 
     get(options = {}) {

--- a/lib/https-server/server.js
+++ b/lib/https-server/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const enableDestroy = require('server-destroy');
 const selfsigned = require('selfsigned');
 const { URL } = require('url');
 const https = require('https');
@@ -37,19 +38,23 @@ class HttpsServer {
                 }`;
                 resolve(this.address);
             });
+            enableDestroy(this.server);
         });
     }
 
     close() {
-        return new Promise((resolve, reject) => {
-            this.server.close((err) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
+        if (this.server) {
+            return new Promise((resolve, reject) => {
+                this.server.destroy((err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
             });
-        });
+        }
+        return Promise.resolve();
     }
 
     get(


### PR DESCRIPTION
This adds a destroy function to the http/https servers to clear out any dangling http connections when the servers are closed. This speeds up tests quite a bit.